### PR TITLE
修复随机字符串生成方法在 PHP 7.4 中因用“{}”访问数组元素被弃用而无法正常工作的 bug

### DIFF
--- a/src/helper/src/RandomStringHelper.php
+++ b/src/helper/src/RandomStringHelper.php
@@ -20,7 +20,7 @@ class RandomStringHelper
         $last  = 61;
         $str   = '';
         for ($i = 0; $i < $length; $i++) {
-            $str .= $chars{mt_rand(0, $last)};
+            $str .= $chars[mt_rand(0, $last)];
         }
         return $str;
     }
@@ -37,9 +37,9 @@ class RandomStringHelper
         $str   = '';
         for ($i = 0; $i < $length; $i++) {
             if ($i == 0) {
-                $str .= $chars{mt_rand(0, $last - 1)};
+                $str .= $chars[mt_rand(0, $last - 1)];
             } else {
-                $str .= $chars{mt_rand(0, $last)};
+                $str .= $chars[mt_rand(0, $last)];
             }
         }
         return $str;


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate_curly_braces_array_access