### PR TITLE
修复 Mix\Console\Error 中 implode 参数顺序不规范导致 PHP7.4 下抛致命错误的问题

### DIFF
--- a/src/console/src/Error.php
+++ b/src/console/src/Error.php
@@ -248,7 +248,7 @@ class Error
             }
             $trace[$key] = ' ' . $value;
         }
-        $context['trace'] = implode($trace, "\n");
+        $context['trace'] = implode("\n", $trace);
         $message          = "{message}\n[code] {code} [type] {type}\n[file] in {file} on line {line}\n{trace}";
         if (!$debug) {
             $message = "{message} [{code}] {type} in {file} on line {line}";


### PR DESCRIPTION
> PHP Fatal error:  Uncaught Mix\Console\Exception\ErrorException: implode(): Passing glue string after array is deprecated.

PHP 7.4 中不能再将 `glue string` 作为第二个参数了

_https://www.php.net/manual/zh/function.implode.php_